### PR TITLE
use struct instead of class, overloading operators

### DIFF
--- a/VerbalExpressions/VerbalExpressions.swift
+++ b/VerbalExpressions/VerbalExpressions.swift
@@ -12,7 +12,7 @@ public func VerEx() -> VerbalExpressions {
     return VerbalExpressions()
 }
 
-public class VerbalExpressions {
+public struct VerbalExpressions {
     // stored properties
     var prefixes = ""
     var source = ""
@@ -21,84 +21,126 @@ public class VerbalExpressions {
 
     // computed properties
     var pattern: String { return prefixes + source + suffixes }
-    
+
     var regularExpression: NSRegularExpression! {
-        get {
-            let regex = try! NSRegularExpression(pattern: pattern, options: options)
-            
-            return regex
-        }
+        return try! NSRegularExpression(pattern: pattern, options: options)
+    }
+    
+    func set(prefixes prefixes: String? = nil, source: String? = nil, suffixes: String? = nil, options: NSRegularExpressionOptions? = nil) -> VerbalExpressions {
+        return VerbalExpressions(
+            prefixes: prefixes ?? self.prefixes,
+            source: source ?? self.source,
+            suffixes: suffixes ?? self.suffixes,
+            options: options ?? self.options
+        )
     }
 
     // instance methods
-    public func startOfLine(enabled enabled: Bool = true) -> Self {
-        prefixes = enabled ? "^" : ""
-
-        return self
+    public func startOfLine(enabled enabled: Bool = true) -> VerbalExpressions {
+        return set(prefixes: enabled ? "^" : "")
     }
 
-    public func endOfLine(enabled enabled: Bool = true) -> Self {
-        suffixes = enabled ? "$" : ""
+    public func endOfLine(enabled enabled: Bool = true) -> VerbalExpressions {
+        return set(suffixes: enabled ? "$" : "")    }
 
-        return self
-    }
-
-    public func then(string: String) -> Self {
+    public func then(string: String) -> VerbalExpressions {
         return add("(?:\(sanitize(string)))")
     }
 
+    public func then(string: VerbalExpressions) -> VerbalExpressions {
+        return add("(?:\(sanitize(string.source)))")
+    }
+
     // alias for then
-    public func find(string: String) -> Self {
+    public func find(string: String) -> VerbalExpressions {
         return then(string)
     }
 
-    public func maybe(string: String) -> Self {
+    public func find(string: VerbalExpressions) -> VerbalExpressions {
+        return then(string)
+    }
+
+    public func maybe(string: String) -> VerbalExpressions {
         return add("(?:\(sanitize(string)))?")
     }
-    
-    public func anything() -> Self {
+
+    public func maybe(string: VerbalExpressions) -> VerbalExpressions {
+        return add("(?:\(sanitize(string.source)))?")
+    }
+
+    public func or() -> VerbalExpressions {
+        return set(prefixes: prefixes + "(?:")
+            .set(suffixes: ")" + suffixes)
+            .add(")|(?:")
+    }
+
+    public func or(value: String) -> VerbalExpressions {
+        return or().then(value)
+    }
+
+    public func or(value: VerbalExpressions) -> VerbalExpressions {
+        return or(value.source);
+    }
+
+    public func anything() -> VerbalExpressions {
         return add("(?:.*)")
     }
-    
-    public func anythingBut(string: String) -> Self {
+
+    public func anythingBut(string: String) -> VerbalExpressions {
         return add("(?:[^\(sanitize(string))]*)")
     }
 
-    public func something() -> Self {
+    public func anythingBut(string: VerbalExpressions) -> VerbalExpressions {
+        return add("(?:[^\(sanitize(string.source))]*)")
+    }
+
+    public func something() -> VerbalExpressions {
         return add("(?:.+)")
     }
 
-    public func somethingBut(string: String) -> Self {
+    public func somethingBut(string: String) -> VerbalExpressions {
         return add("(?:[^\(sanitize(string))]+)")
     }
 
-    public func lineBreak() -> Self {
+    public func somethingBut(string: VerbalExpressions) -> VerbalExpressions {
+        return add("(?:[^\(sanitize(string.source))]+)")
+    }
+
+    public func lineBreak() -> VerbalExpressions {
         return add("(?:(?:\n)|(?:\r\n))")
     }
 
     // alias for lineBreak
-    public func br() -> Self {
+    public func br() -> VerbalExpressions {
         return lineBreak()
     }
 
-    public func tab() -> Self {
+    public func tab() -> VerbalExpressions {
         return add("\t")
     }
 
-    public func word() -> Self {
+    public func word() -> VerbalExpressions {
         return add("\\w+")
     }
-    
-    public func anyOf(string: String) -> Self {
+
+    public func anyOf(string: String) -> VerbalExpressions {
         return add("(?:[\(sanitize(string))])")
     }
-    
+
+    public func anyOf(string: VerbalExpressions) -> VerbalExpressions {
+        return add("(?:[\(sanitize(string.source))])")
+    }
+
     // alias for anyOf
-    public func any(string: String) -> Self {
+    public func any(string: String) -> VerbalExpressions {
         return anyOf(string)
     }
 
-    public func withAnyCase(enabled enabled: Bool = true) -> Self {
+    public func any(string: VerbalExpressions) -> VerbalExpressions {
+        return anyOf(string.source)
+    }
+
+    public func withAnyCase(enabled enabled: Bool = true) -> VerbalExpressions {
         if enabled {
             return addModifier("i")
         }
@@ -106,8 +148,8 @@ public class VerbalExpressions {
             return removeModifier("i")
         }
     }
-    
-    public func searchOneLine(enabled enabled: Bool = true) -> Self {
+
+    public func searchOneLine(enabled enabled: Bool = true) -> VerbalExpressions {
         if enabled {
             return removeModifier("m")
         }
@@ -115,72 +157,74 @@ public class VerbalExpressions {
             return addModifier("m")
         }
     }
-    
-    public func beginCapture() -> Self {
-        suffixes += ")"
-        
-        return add("(")
+
+    public func beginCapture() -> VerbalExpressions {
+        return set(suffixes: suffixes + ")")
+            .add("(")
     }
-    
-    public func endCapture() -> Self {
-        suffixes = suffixes[suffixes.startIndex..<suffixes.endIndex.predecessor()]
-        
-        return add(")")
+
+    public func endCapture() -> VerbalExpressions {
+        return set(suffixes: suffixes[suffixes.startIndex..<suffixes.endIndex.predecessor()])
+            .add(")")
     }
-    
+
     public func replace(string: String, template: String) -> String {
         let range = NSRange(location: 0, length: string.utf16.count)
-        
+
         return regularExpression.stringByReplacingMatchesInString(string, options: [], range: range, withTemplate: template)
     }
-    
+
     public func replace(string: String, with: String) -> String {
         let range = NSRange(location: 0, length: string.utf16.count)
         let template = NSRegularExpression.escapedTemplateForString(with)
-        
+
         return regularExpression.stringByReplacingMatchesInString(string, options: [], range: range, withTemplate: template)
     }
-    
+
     public func test(string: String) -> Bool {
         let range = NSRange(location: 0, length: string.utf16.count)
-        
+
         if let result = regularExpression.firstMatchInString(string, options: [], range: range) {
             return result.range.location != NSNotFound
         }
-        
+
         return false
     }
-    
-    
+
     // internal methods
-    
+
     func sanitize(string: String) -> String {
         return NSRegularExpression.escapedPatternForString(string)
     }
-    
-    func add(string: String) -> Self {
-        source += string
-        
-        return self
+
+    func add(string: String) -> VerbalExpressions {
+        return set(source: source + string)
     }
-    
-    func addModifier(modifier: Character) -> Self {
+
+    func addModifier(modifier: Character) -> VerbalExpressions {
         if let option = option(forModifier: modifier) {
-            options.insert(option)
+            if( options.union(option) != options ){
+                return set(options: options.union(option))
+            }
         }
-        
         return self
     }
-    
-    
-    func removeModifier(modifier: Character) -> Self {
+
+    func addModifier(modifier: NSRegularExpressionOptions) -> VerbalExpressions {
+        if( options != options.union(modifier) ){
+            return set(options: options.union(modifier))
+        }
+        return self
+    }
+
+    func removeModifier(modifier: Character) -> VerbalExpressions {
         if let option = option(forModifier: modifier) where options.contains(option) {
-            options.remove(option)
+            return set(options: options.subtract(option))
         }
-        
+
         return self
     }
-    
+
     func option(forModifier modifier: Character) -> NSRegularExpressionOptions? {
         switch modifier {
         case "d": // UREGEX_UNIX_LINES
@@ -208,7 +252,6 @@ extension VerbalExpressions: CustomStringConvertible {
     public var description: String { return pattern }
 }
 
-
 // Match operators
 // Adapted from https://gist.github.com/JimRoepcke/d68dd41ee2fedc6a0c67
 infix operator =~  { associativity left precedence 140 }
@@ -218,6 +261,14 @@ public func =~(lhs: String, rhs: VerbalExpressions) -> Bool {
     return rhs.test(lhs)
 }
 
+public func =~(lhs: VerbalExpressions, rhs: String) -> Bool {
+    return lhs.test(rhs)
+}
+
 public func !=~(lhs: String, rhs: VerbalExpressions) -> Bool {
+    return !(lhs =~ rhs)
+}
+
+public func !=~(lhs: VerbalExpressions, rhs: String) -> Bool {
     return !(lhs =~ rhs)
 }

--- a/VerbalExpressionsTests/VerbalExpressionsTests.swift
+++ b/VerbalExpressionsTests/VerbalExpressionsTests.swift
@@ -12,27 +12,27 @@ import VerbalExpressions
 class VerbalExpressionsTests: XCTestCase {
     
     func testStartOfLine() {
-        let tester = VerEx()
+        var tester = VerEx()
             .startOfLine()
             .then("a")
         
         XCTAssert(tester.test("a"),   "starts with an a")
         XCTAssert(!tester.test("ba"), "doesn't start with an a")
         
-        tester.startOfLine(enabled: false)
+        tester = tester.startOfLine(enabled: false)
         XCTAssert(tester.test("ba"), "contains an a")
         XCTAssert(!tester.test("b"), "doesn't contain an a")
     }
     
     func testEndOfLine() {
-        let tester = VerEx()
+        var tester = VerEx()
             .find("a")
             .endOfLine()
         
         XCTAssert(tester.test("a"),   "ends with an a")
         XCTAssert(!tester.test("ab"), "doesn't end with an a")
         
-        tester.endOfLine(enabled: false)
+        tester = tester.endOfLine(enabled: false)
         XCTAssert(tester.test("ab"), "contains an a")
         XCTAssert(!tester.test("b"), "doesn't contain an a")
     }
@@ -168,18 +168,18 @@ class VerbalExpressionsTests: XCTestCase {
     }
     
     func testWithAnyCase() {
-        let tester = VerEx()
+        var tester = VerEx()
             .startOfLine()
             .then("a")
         
         XCTAssert(tester.test("a"),  "tests case sensitive by default")
         XCTAssert(!tester.test("A"), "tests case sensitive by default")
         
-        tester.withAnyCase()
+        tester = tester.withAnyCase()
         XCTAssert(tester.test("a"),  "tests case insensitive")
         XCTAssert(tester.test("A"),  "tests case insensitive")
         
-        tester.withAnyCase(enabled: false)
+        tester = tester.withAnyCase(enabled: false)
         XCTAssert(tester.test("a"),  "tests case insensitive")
         XCTAssert(!tester.test("A"), "tests case insensitive")
     }


### PR DESCRIPTION
1. Updated Class to be a Struct instead. This makes the whole thing immutable, and get value semantics. A regular expression is clearly 'data' and should have value semantics.
2. Added two more functions for the custom operators, which just allow you to reverse the arguments.
   if `a =~ b` is true, `b =~ a` should also be true. This can be done because string matching is commutative.
